### PR TITLE
Bump v0.1.9 policy version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "allowed-proc-mount-types-psp"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "k8s-openapi",
  "kubewarden-policy-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allowed-proc-mount-types-psp"
-version = "0.1.8"
+version = "0.1.9"
 authors = ["Rafael Fernández López <ereslibre@ereslibre.es>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,29 +4,29 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.8
+version: 0.1.9
 name: allowed-proc-mount-types-psp
 displayName: Allowed Proc Mount Types PSP
-createdAt: 2023-03-24T15:57:38.973587225Z
+createdAt: 2023-07-07T17:53:44.474033628Z
 description: Replacement for the Kubernetes Pod Security Policy that controls the usage of /proc mount types
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.8
+  image: ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.9
 keywords:
 - psp
 - container
 - runtime
 links:
 - name: policy
-  url: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy/releases/download/v0.1.8/policy.wasm
+  url: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy/releases/download/v0.1.9/policy.wasm
 - name: source
   url: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.8
+  kwctl pull ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.9
   ```
 maintainers:
 - name: Kubewarden developers


### PR DESCRIPTION
## Description

Updates the Cargo and artifacthub files bumping the policy version to v0.1.9.

Related to https://github.com/kubewarden/kubewarden-controller/issues/479