### PR TITLE
fix: Use correct rules for `ephemeralcontainers`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "allowed-proc-mount-types-psp"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "k8s-openapi",
  "kubewarden-policy-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allowed-proc-mount-types-psp"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Rafael Fernández López <ereslibre@ereslibre.es>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,33 +4,33 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.9
+version: 0.1.10
 name: allowed-proc-mount-types-psp
 displayName: Allowed Proc Mount Types PSP
-createdAt: 2023-10-16T08:29:41.923293545Z
+createdAt: 2024-07-17T14:23:02.94346891Z
 description: Replacement for the Kubernetes Pod Security Policy that controls the usage of /proc mount types
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.9
+  image: ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.10
 keywords:
 - psp
 - container
 - runtime
 links:
 - name: policy
-  url: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy/releases/download/v0.1.9/policy.wasm
+  url: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy/releases/download/v0.1.10/policy.wasm
 - name: source
   url: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.9
+  kwctl pull ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.10
   ```
   Then, generate the policy manifest and tune it to your liking. For example:
   ```console
-  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.9
+  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.10
   ```
 maintainers:
 - name: Kubewarden developers
@@ -76,6 +76,5 @@ annotations:
       - v1
       resources:
       - pods
-      - pods/ephemeralcontainers
       operations:
       - UPDATE

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,6 +1,6 @@
 rules:
   - apiGroups:
-      - ''
+      - ""
     apiVersions:
       - v1
     resources:
@@ -9,12 +9,11 @@ rules:
     operations:
       - CREATE
   - apiGroups:
-      - ''
+      - ""
     apiVersions:
       - v1
     resources:
       - pods
-      - pods/ephemeralcontainers
     operations:
       - UPDATE
 mutating: false
@@ -28,7 +27,8 @@ annotations:
   # kubewarden specific
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp
   io.kubewarden.policy.title: allowed-proc-mount-types-psp
-  io.kubewarden.policy.description: Replacement for the Kubernetes Pod Security Policy
+  io.kubewarden.policy.description:
+    Replacement for the Kubernetes Pod Security Policy
     that controls the usage of /proc mount types
   io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.url: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Relates to https://github.com/kubewarden/allowed-proc-mount-types-psp-policy/issues/57

Set correct rules for `ephemeralcontainers`.
Prepare for release.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
