### PR TITLE
fix: Correctly remove `pods/ephemeralcontainers` from metadata rules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "allowed-proc-mount-types-psp"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "k8s-openapi",
  "kubewarden-policy-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "allowed-proc-mount-types-psp"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Rafael Fernández López <ereslibre@ereslibre.es>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,33 +4,33 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.10
+version: 0.1.11
 name: allowed-proc-mount-types-psp
 displayName: Allowed Proc Mount Types PSP
-createdAt: 2024-07-17T14:23:02.94346891Z
+createdAt: 2024-07-19T13:11:32.076318453Z
 description: Replacement for the Kubernetes Pod Security Policy that controls the usage of /proc mount types
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.10
+  image: ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.11
 keywords:
 - psp
 - container
 - runtime
 links:
 - name: policy
-  url: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy/releases/download/v0.1.10/policy.wasm
+  url: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy/releases/download/v0.1.11/policy.wasm
 - name: source
   url: https://github.com/kubewarden/allowed-proc-mount-types-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.10
+  kwctl pull ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.11
   ```
   Then, generate the policy manifest and tune it to your liking. For example:
   ```console
-  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.10
+  kwctl scaffold manifest -t ClusterAdmissionPolicy registry://ghcr.io/kubewarden/policies/allowed-proc-mount-types-psp:v0.1.11
   ```
 maintainers:
 - name: Kubewarden developers
@@ -67,7 +67,6 @@ annotations:
       - v1
       resources:
       - pods
-      - pods/ephemeralcontainers
       operations:
       - CREATE
     - apiGroups:

--- a/metadata.yml
+++ b/metadata.yml
@@ -5,7 +5,6 @@ rules:
       - v1
     resources:
       - pods
-      - pods/ephemeralcontainers
     operations:
       - CREATE
   - apiGroups:


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
Fix https://github.com/kubewarden/allowed-proc-mount-types-psp-policy/issues/57

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
CI.

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
